### PR TITLE
Fix the testing to not skip.

### DIFF
--- a/molecule/archiveinterface/molecule.yml
+++ b/molecule/archiveinterface/molecule.yml
@@ -8,6 +8,7 @@ lint:
 platforms:
   - name: centos
     image: centos:7
+    privileged: true
     capabilities:
       - SYS_ADMIN
     volumes:
@@ -15,6 +16,7 @@ platforms:
     command: /usr/lib/systemd/systemd
   - name: ubuntu
     image: ubuntu:18.04
+    privileged: true
     capabilities:
       - SYS_ADMIN
     volumes:

--- a/molecule/core/molecule.yml
+++ b/molecule/core/molecule.yml
@@ -8,6 +8,7 @@ lint:
 platforms:
   - name: centos
     image: centos:7
+    privileged: true
     capabilities:
       - SYS_ADMIN
     volumes:
@@ -15,6 +16,7 @@ platforms:
     command: /usr/lib/systemd/systemd
   - name: ubuntu
     image: ubuntu:18.04
+    privileged: true
     capabilities:
       - SYS_ADMIN
     volumes:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,6 +8,7 @@ lint:
 platforms:
   - name: centos
     image: centos:7
+    privileged: true
     capabilities:
       - SYS_ADMIN
     volumes:
@@ -15,6 +16,7 @@ platforms:
     command: /usr/lib/systemd/systemd
   - name: ubuntu
     image: ubuntu:18.04
+    privileged: true
     capabilities:
       - SYS_ADMIN
     volumes:

--- a/molecule/in/molecule.yml
+++ b/molecule/in/molecule.yml
@@ -8,6 +8,7 @@ lint:
 platforms:
   - name: centos
     image: centos:7
+    privileged: true
     capabilities:
       - SYS_ADMIN
     volumes:
@@ -15,6 +16,7 @@ platforms:
     command: /usr/lib/systemd/systemd
   - name: ubuntu
     image: ubuntu:18.04
+    privileged: true
     capabilities:
       - SYS_ADMIN
     volumes:

--- a/molecule/in/tests/test_ingest.py
+++ b/molecule/in/tests/test_ingest.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Testing module for ingest to verify working."""
-from pytest import mark
 
 
 def test_ingest_socket(host):
@@ -20,7 +19,6 @@ def check_ingest_frontend_service(host):
     assert host.service('ingest_frontend').is_running
 
 
-@mark.skip(reason='no way of currently testing this')
 def test_ingest_return(host):
     """Check that ingest returns properly."""
     command = """curl --digest -L -D - http://localhost:8066/"""

--- a/molecule/notify/molecule.yml
+++ b/molecule/notify/molecule.yml
@@ -8,6 +8,7 @@ lint:
 platforms:
   - name: centos
     image: centos:7
+    privileged: true
     capabilities:
       - SYS_ADMIN
     volumes:
@@ -15,6 +16,7 @@ platforms:
     command: /usr/lib/systemd/systemd
   - name: ubuntu
     image: ubuntu:18.04
+    privileged: true
     capabilities:
       - SYS_ADMIN
     volumes:

--- a/molecule/notify/tests/test_notify.py
+++ b/molecule/notify/tests/test_notify.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Testing module for notifictaions to verify working."""
-from pytest import mark
 
 
 def test_notifications_socket(host):
@@ -20,7 +19,6 @@ def check_notify_frontend_service(host):
     assert host.service('ingest_frontend').is_running
 
 
-@mark.skip(reason='no way of currently testing this')
 def test_notifications_return(host):
     """Check that notifications returns properly."""
     command = """curl --digest -L -D - http://localhost:8070/"""

--- a/molecule/out/molecule.yml
+++ b/molecule/out/molecule.yml
@@ -8,6 +8,7 @@ lint:
 platforms:
   - name: centos
     image: centos:7
+    privileged: true
     capabilities:
       - SYS_ADMIN
     volumes:
@@ -15,6 +16,7 @@ platforms:
     command: /usr/lib/systemd/systemd
   - name: ubuntu
     image: ubuntu:18.04
+    privileged: true
     capabilities:
       - SYS_ADMIN
     volumes:

--- a/molecule/out/tests/test_cartd.py
+++ b/molecule/out/tests/test_cartd.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Testing module for cartd to verify working."""
-from pytest import mark
 
 
 def test_cartd_socket(host):
@@ -20,7 +19,6 @@ def check_cartd_frontend_service(host):
     assert host.service('cartd_frontend').is_running
 
 
-@mark.skip(reason='no way of currently testing this')
 def test_cartd_return(host):
     """Check that cartd returns properly."""
     command = """curl --digest -L -D - http://localhost:8081/"""

--- a/vars/defaults/cartd_backend.yml
+++ b/vars/defaults/cartd_backend.yml
@@ -3,5 +3,5 @@ pacifica_module: cartd
 celery: true
 no_db: true
 env_vars:
-  CARTD_CONFIG: "/opt/default/cartd.ini"
-  CARTD_CPCONFIG: "/opt/default/cartd-cp.ini"
+  CARTD_CONFIG: "/opt/default/cartd_backend.ini"
+  CARTD_CPCONFIG: "/opt/default/cartd_backend-cp.ini"

--- a/vars/defaults/cartd_frontend.yml
+++ b/vars/defaults/cartd_frontend.yml
@@ -2,5 +2,5 @@
 pacifica_module: cartd
 socket_port: "8081"
 env_vars:
-  CARTD_CONFIG: "/opt/default/cartd.ini"
-  CARTD_CPCONFIG: "/opt/default/cartd-cp.ini"
+  CARTD_CONFIG: "/opt/default/cartd_frontend.ini"
+  CARTD_CPCONFIG: "/opt/default/cartd_frontend-cp.ini"

--- a/vars/defaults/ingest_backend.yml
+++ b/vars/defaults/ingest_backend.yml
@@ -3,5 +3,5 @@ pacifica_module: ingest
 celery: true
 no_db: true
 env_vars:
-  INGEST_CONFIG: "/opt/default/ingest.ini"
-  INGEST_CPCONFIG: "/opt/default/ingest-cp.ini"
+  INGEST_CONFIG: "/opt/default/ingest_backend.ini"
+  INGEST_CPCONFIG: "/opt/default/ingest_backend-cp.ini"

--- a/vars/defaults/ingest_frontend.yml
+++ b/vars/defaults/ingest_frontend.yml
@@ -2,5 +2,5 @@
 pacifica_module: ingest
 socket_port: "8066"
 env_vars:
-  INGEST_CONFIG: "/opt/default/ingest.ini"
-  INGEST_CPCONFIG: "/opt/default/ingest-cp.ini"
+  INGEST_CONFIG: "/opt/default/ingest_frontend.ini"
+  INGEST_CPCONFIG: "/opt/default/ingest_frontend-cp.ini"

--- a/vars/defaults/notify_backend.yml
+++ b/vars/defaults/notify_backend.yml
@@ -3,5 +3,5 @@ pacifica_module: notifications
 celery: true
 no_db: true
 env_vars:
-  NOTIFICATIONS_CONFIG: "/opt/default/notifications.ini"
-  NOTIFICATIONS_CPCONFIG: "/opt/default/notifications-cp.ini"
+  NOTIFICATIONS_CONFIG: "/opt/default/notify_backend.ini"
+  NOTIFICATIONS_CPCONFIG: "/opt/default/notify_backend-cp.ini"

--- a/vars/defaults/notify_frontend.yml
+++ b/vars/defaults/notify_frontend.yml
@@ -2,5 +2,5 @@
 pacifica_module: notifications
 socket_port: "8070"
 env_vars:
-  NOTIFICATIONS_CONFIG: "/opt/default/notifications.ini"
-  NOTIFICATIONS_CPCONFIG: "/opt/default/notifications-cp.ini"
+  NOTIFICATIONS_CONFIG: "/opt/default/notify_frontend.ini"
+  NOTIFICATIONS_CPCONFIG: "/opt/default/notify_frontend-cp.ini"


### PR DESCRIPTION
### Description

This got the testing to work without skipping on my Ubuntu 18.04 system...

 * Add privileged docker container option
 * Remove the skip decorator from in/out/notify tests
 * Fix CherryPy and Pacifica default configuration file paths

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix https://github.com/pacifica/ansible-pacifica/pull/13

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
